### PR TITLE
snap: add desktop interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,6 +13,7 @@ apps:
   bhttp:
     command: bin/bhttp
     plugs:
+      - desktop
       - home
       - network
       - network-bind


### PR DESCRIPTION
Add the "desktop" interface so that bhttp can open the browser for authentication